### PR TITLE
README.md  - link to Jansson lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ jsonrpc_server.c is an example of usage using ZeroMQ as a transport.
 It has been tested against ZeroMQ 3.2.2 and jansson 2.3.1
 
 
-Since significant functionality is provided by jansson library, the same licence is chosen to be used by this code.
+Since significant functionality is provided by [jansson library](https://github.com/akheron/jansson), the same licence is chosen to be used by this code.


### PR DESCRIPTION
Add a link to the Jansson library, so that it's explicit which library we are referring to.